### PR TITLE
[FIX] 불필요한 스타일 정보 필드 삭제

### DIFF
--- a/src/main/java/kuit/modi/domain/CharacterType.java
+++ b/src/main/java/kuit/modi/domain/CharacterType.java
@@ -17,7 +17,4 @@ public class CharacterType {
 
     @Column(nullable = false, unique = true, length = 30)
     private String name;
-
-    @Column(name = "image_url", columnDefinition = "TEXT")
-    private String imageUrl; // 사용할지 여부는 나중에 결정
 }

--- a/src/main/java/kuit/modi/domain/Frame.java
+++ b/src/main/java/kuit/modi/domain/Frame.java
@@ -17,7 +17,4 @@ public class Frame {
 
     @Column(nullable = false, unique = true, length = 30)
     private String name;
-
-    @Column(name = "style_info", columnDefinition = "TEXT")
-    private String styleInfo; // 프레임 스타일 관련 JSON 등 저장 가능
 }


### PR DESCRIPTION
프론트에서 저장한다고 했던 필드 두 가지 삭제했습니다! 
(Frame속 style 정보 필드, CharacterType의 캐릭터 이미지 정보 필드)