### PR TITLE
리마인더 알림 생성/조회 시 Location 처리 오류 수정 및 Hibernate sql 로그 삭제

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ out/
 .env
 
 ### application-secret.yml ###
-appliction-secret.yml
+src/main/resources/application-secret.yml

--- a/src/main/java/kuit/modi/repository/DiaryRepository.java
+++ b/src/main/java/kuit/modi/repository/DiaryRepository.java
@@ -13,26 +13,29 @@ import java.util.List;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     void deleteAllByMemberId(Long memberId);
-    List<Diary> findByMemberAndLocationOrderByDateDesc(Member member, Location location);
+
     // === 커서 기반 페이징 추가 === //
     @Query("""
-        SELECT d FROM Diary d
-        WHERE d.member.id = :memberId
-          AND d.location.id = :locationId
-          AND (
-                :cursorCreatedAt IS NULL
-                OR (
-                     d.createdAt < :cursorCreatedAt
-                     OR (d.createdAt = :cursorCreatedAt AND d.id < :cursorId)
-                   )
-              )
-        ORDER BY d.createdAt DESC, d.id DESC
+        select d from Diary d
+        where d.member.id = :memberId
+            and d.location.id in :locationIds
+            and (
+                :cursorCreatedAt is null
+                or d.createdAt < :cursorCreatedAt
+                or (d.createdAt = :cursorCreatedAt and d.id < :cursorId)
+                )
+        order by d.createdAt desc, d.id desc
     """)
-    List<Diary> findPagedDiaries(
+    List<Diary> findPagedDiariesByLocations(
             @Param("memberId") Long memberId,
-            @Param("locationId") Long locationId,
+            @Param("locationIds") List<Long> locationIds,
             @Param("cursorCreatedAt") Instant cursorCreatedAt,
             @Param("cursorId") Long cursorId,
             Pageable pageable
+    );
+
+    List<Diary> findByMemberAndLocationInOrderByDateDesc(
+            Member member,
+            List<Location> locations
     );
 }

--- a/src/main/java/kuit/modi/repository/LocationRepository.java
+++ b/src/main/java/kuit/modi/repository/LocationRepository.java
@@ -3,9 +3,11 @@ package kuit.modi.repository;
 import kuit.modi.domain.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
     Optional<Location> findByAddress(String address);
+    List<Location> findAllByAddress(String address);
     Optional<Location> findByAddressAndLatitudeAndLongitude(String address, Double latitude, Double longitude);
 }

--- a/src/main/java/kuit/modi/service/ReminderService.java
+++ b/src/main/java/kuit/modi/service/ReminderService.java
@@ -33,13 +33,15 @@ public class ReminderService {
     private static final String DEFAULT_THUMBNAIL = "https://cdn.modi.com/diary/default-thumb.jpg";
 
     public ReminderResponse createReminder(Member member, String address) {
-        // 주소 → Location 조회
-        Location location = locationRepository.findByAddress(address)
-                .orElseThrow(() -> new IllegalArgumentException("해당 주소가 존재하지 않습니다."));
+        // 주소에 해당하는 모든 Location 조회
+        List<Location> locations = locationRepository.findAllByAddress(address);
+        if (locations.isEmpty()) {
+            throw new IllegalArgumentException("해당 주소가 존재하지 않습니다.");
+        }
 
-        // 해당 위치에서 사용자가 작성한 다이어리 최신 1개 조회
+        // 해당 Location들에 대한 Diary 조회 (최신순)
         List<Diary> diaries =
-                diaryRepository.findByMemberAndLocationOrderByDateDesc(member, location);
+                diaryRepository.findByMemberAndLocationInOrderByDateDesc(member, locations);
 
         if (diaries.isEmpty()) {
             throw new IllegalArgumentException("해당 위치에 대한 다이어리 기록이 없습니다.");
@@ -47,11 +49,11 @@ public class ReminderService {
 
         Diary latest = diaries.get(0);
 
-        // Reminder 생성 및 저장
+        // Reminder 생성
         Reminder reminder = new Reminder(
                 null,
                 null,
-                location,
+                latest.getLocation(),
                 latest.getDate(),
                 latest.getEmotion(),
                 member
@@ -59,24 +61,29 @@ public class ReminderService {
         reminderRepository.save(reminder);
 
         // 응답 생성
-        return new ReminderResponse(reminder.getId(),
+        return new ReminderResponse(
+                reminder.getId(),
                 reminder.getCreatedAt(),
                 reminder.getLocation().getAddress(),
                 reminder.getLastVisit(),
-                reminder.getEmotion().getName());
+                reminder.getEmotion().getName()
+        );
     }
 
     public ReminderPagedResponse getRemindersByAddress(
             Member member,
             ReminderQueryParams params
     ) {
-        // 1. address → Location 조회
-        Location location = locationRepository.findByAddress(params.address())
-                .orElse(null);
+        // 1. address → Locations 조회
+        List<Location> locations = locationRepository.findAllByAddress(params.address());
 
-        if (location == null) {
+        if (locations.isEmpty()) {
             return new ReminderPagedResponse(List.of(), null);
         }
+
+        List<Long> locationIds = locations.stream()
+                .map(Location::getId)
+                .toList();
 
         // 2. limit 기본값 설정
         int limit = (params.limit() == null) ? 20 : params.limit();
@@ -101,9 +108,9 @@ public class ReminderService {
         }
 
         // 4. DB 조회
-        List<Diary> diaries = diaryRepository.findPagedDiaries(
+        List<Diary> diaries = diaryRepository.findPagedDiariesByLocations(
                 member.getId(),
-                location.getId(),
+                locationIds,
                 cursorCreatedAt,
                 cursorId,
                 pageable

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: modi
 
   config:
-    import: optional:file:/config/application-secret.yml
+    import: optional:classpath:application-secret.yml
 
   h2:
     console:
@@ -20,7 +20,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
-        show_sql: true
+        show_sql: false
         format_sql: true
         use_sql_comments: true
     hibernate:


### PR DESCRIPTION
1. 리마인더 알림 생성/조회 시 같은 위치(예: 서울 광진구 화양동)에 대해 여러 개의 Location 객체가 존재하여 발생하는 오류를 해결하였습니다.
2. Hibernate sql 로그가 너무 많은 부분을 차지하여 가독성이 떨어지는 것 같아 application.yml에서 show_sql: false로 수정하였습니다.