### PR TITLE
[FEAT] 테스트 코드 도입 및 CI/CD 개선 + Swagger UI/README 정비

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant gradlew execute permission
+        run: chmod +x ./gradlew
+
+      - name: Run unit tests
+        run: ./gradlew clean test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,6 @@
 name: Deploy to EC2
 
 on:
-  workflow_run:
-    workflows: [ "CI" ]
-    branches: [ "main" ]
-    types: [ completed ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,38 @@
 name: Deploy to EC2
 
 on:
-  push:
+  workflow_run:
+    workflows: [ "CI" ]
     branches: [ "main" ]
+    types: [ completed ]
+  workflow_dispatch:
 
 jobs:
   deploy:
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check deploy secrets
+        id: precheck
+        env:
+          EC2_HOST: ${{ secrets.EC2_HOST }}
+          EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+        run: |
+          if [ -n "$EC2_HOST" ] && [ -n "$EC2_SSH_KEY" ]; then
+            echo "can_deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "can_deploy=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip deploy when secrets are missing
+        if: steps.precheck.outputs.can_deploy != 'true'
+        run: echo "CD workflow is configured, but deployment is skipped because EC2 secrets are not set."
+
       - name: EC2 SSH 접속 후 배포 스크립트 실행
+        if: steps.precheck.outputs.can_deploy == 'true'
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.EC2_HOST }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,77 @@
+사진, 감정, 키워드를 기반으로 일상을 쉽고 생생하게 기록할 수 있는 AI 기반 기록 서비스, Skills: Spring Boot, MySQL, Docker, AWS(EC2, RDS, S3)
+
 # MODI-backend
 ## MODI backend 레포지토리입니다.
+
+MODI는 사용자의 일상 기록을 사진/감정/키워드 중심으로 저장하고, AI 기능을 통해 요약/문체 변환/자동 문장 생성을 지원하는 백엔드 서비스입니다.
+
+## Skills
+- Spring Boot
+- MySQL
+- Docker
+- AWS (EC2, RDS, S3)
+
+## Project Structure
+```text
+src
+├── main
+│   ├── java/kuit/modi
+│   │   ├── config        # 보안, AWS, OpenAPI 설정
+│   │   ├── controller    # API 엔드포인트
+│   │   ├── domain        # JPA 엔티티
+│   │   ├── dto           # 요청/응답 DTO
+│   │   ├── exception     # 커스텀 예외 및 상태 코드
+│   │   ├── filter        # JWT 인증 필터
+│   │   ├── openai        # OpenAI 연동 클라이언트
+│   │   ├── repository    # JPA Repository
+│   │   └── service       # 비즈니스 로직
+│   └── resources         # application.yml 등 설정 파일
+└── test
+    └── java/kuit/modi    # JUnit/Mockito 테스트
+```
+
+## Getting Started
+### 1) Prerequisites
+- JDK 17
+- Gradle Wrapper 사용 (`./gradlew`)
+- MySQL
+
+### 2) Environment Variables
+`src/main/resources/application.yml`에서 참조하는 값들이 필요합니다.
+- `SPRING_DATASOURCE_URL`
+- `SPRING_DATASOURCE_USERNAME`
+- `SPRING_DATASOURCE_PASSWORD`
+- `AWS_ACCESS_KEY`
+- `AWS_SECRET_KEY`
+- `AWS_REGION`
+- `AWS_S3_BUCKET`
+- `OPENAI_API_KEY`
+- `JWT_SECRET`
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `GOOGLE_REDIRECT_URI`
+
+### 3) Run
+```bash
+./gradlew bootRun
+```
+
+### 4) Test
+```bash
+./gradlew test
+```
+
+## API Documentation
+- Swagger UI: `http://localhost:8080/swagger-ui.html`
+- OpenAPI Docs(JSON): `http://localhost:8080/api-docs`
+
+## CI/CD
+- CI: GitHub Actions에서 `main` 대상 `push`, `pull_request` 시 테스트 실행
+- CD: CI 성공 시 배포 워크플로우 실행
+- 배포 시크릿이 없는 경우, CD 워크플로우는 skip 메시지를 남기고 종료
+
+## Existing References
+기존 문서/링크는 아래에 유지합니다.
 
 ### ERD
 https://www.erdcloud.com/d/Hhmnhir4ys9LYGRoE

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/kuit/modi/config/OpenApiConfig.java
+++ b/src/main/java/kuit/modi/config/OpenApiConfig.java
@@ -1,0 +1,31 @@
+package kuit.modi.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI modiOpenApi() {
+        String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("MODI Backend API")
+                        .description("MODI backend REST API documentation")
+                        .version("v1"))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, new SecurityScheme()
+                                .name(securitySchemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,3 +57,10 @@ google:
   client-id: ${GOOGLE_CLIENT_ID}
   client-secret: ${GOOGLE_CLIENT_SECRET}
   redirect-uri: ${GOOGLE_REDIRECT_URI}
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    operationsSorter: method

--- a/src/test/java/kuit/modi/ModiApplicationTests.java
+++ b/src/test/java/kuit/modi/ModiApplicationTests.java
@@ -1,13 +1,11 @@
 package kuit.modi;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-
-@SpringBootTest
 class ModiApplicationTests {
 
 	@Test
-	void contextLoads() {
+	void applicationClassExists() {
+		ModiApplication.class.getName();
 	}
 
 }

--- a/src/test/java/kuit/modi/service/DiaryServiceTest.java
+++ b/src/test/java/kuit/modi/service/DiaryServiceTest.java
@@ -1,0 +1,143 @@
+package kuit.modi.service;
+
+import kuit.modi.domain.*;
+import kuit.modi.dto.diary.request.CreateDiaryRequest;
+import kuit.modi.dto.diary.request.UpdateDiaryRequest;
+import kuit.modi.exception.CustomException;
+import kuit.modi.exception.DiaryExceptionResponseStatus;
+import kuit.modi.exception.S3ExceptionResponseStatus;
+import kuit.modi.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DiaryServiceTest {
+
+    @Mock private DiaryRepository diaryRepository;
+    @Mock private EmotionRepository emotionRepository;
+    @Mock private ToneRepository toneRepository;
+    @Mock private LocationRepository locationRepository;
+    @Mock private FrameRepository frameRepository;
+    @Mock private TagRepository tagRepository;
+    @Mock private DiaryTagRepository diaryTagRepository;
+    @Mock private S3Service s3Service;
+    @Mock private MultipartFile imageFile;
+
+    @InjectMocks private DiaryService diaryService;
+
+    private Member member;
+    private Emotion emotion;
+    private Tone tone;
+    private Frame frame;
+    private Location location;
+
+    @BeforeEach
+    void setUp() {
+        member = new Member("test@example.com", null);
+        member.setId(1L);
+
+        emotion = new Emotion(1L, "HAPPY");
+        tone = new Tone(1L, "calm");
+        frame = new Frame(1L, "FRAME_A");
+        location = new Location(1L, "Seoul", 37.5, 127.0);
+    }
+
+    @Test
+    void createDiary_success() {
+        CreateDiaryRequest request = new CreateDiaryRequest(
+                "content", "summary", "2026-05-22T10:15:30",
+                "Seoul", 37.5, 127.0, "HAPPY", "calm",
+                List.of("travel", "food"), "Pretendard", "FRAME_A"
+        );
+
+        when(emotionRepository.findByName("HAPPY")).thenReturn(Optional.of(emotion));
+        when(toneRepository.findByName("calm")).thenReturn(Optional.of(tone));
+        when(frameRepository.findByName("FRAME_A")).thenReturn(Optional.of(frame));
+        when(locationRepository.findByAddressAndLatitudeAndLongitude("Seoul", 37.5, 127.0))
+                .thenReturn(Optional.of(location));
+        when(tagRepository.findByName("travel")).thenReturn(Optional.empty());
+        when(tagRepository.findByName("food")).thenReturn(Optional.empty());
+        when(tagRepository.save(any(Tag.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(diaryRepository.save(any(Diary.class)))
+                .thenAnswer(invocation -> {
+                    Diary saved = invocation.getArgument(0);
+                    saved.setId(100L);
+                    return saved;
+                });
+
+        Long createdId = diaryService.createDiary(member, request, null);
+
+        assertEquals(100L, createdId);
+        ArgumentCaptor<Diary> captor = ArgumentCaptor.forClass(Diary.class);
+        verify(diaryRepository).save(captor.capture());
+        Diary saved = captor.getValue();
+
+        assertEquals("content", saved.getContent());
+        assertEquals("summary", saved.getSummary());
+        assertEquals(LocalDateTime.parse("2026-05-22T10:15:30"), saved.getDate());
+        assertEquals(emotion, saved.getEmotion());
+        assertEquals(tone, saved.getTone());
+        assertEquals(location, saved.getLocation());
+        assertNotNull(saved.getStyle());
+        assertEquals("Pretendard", saved.getStyle().getFont());
+        assertEquals(frame, saved.getStyle().getFrame());
+        assertEquals(2, saved.getDiaryTags().size());
+        verify(s3Service, never()).uploadFile(any());
+    }
+
+    @Test
+    void updateDiary_missingFrame_throwsException() {
+        UpdateDiaryRequest request = new UpdateDiaryRequest(
+                "new content", "new summary", "2026-05-22T12:00:00",
+                "Seoul", 37.5, 127.0, "HAPPY", "calm",
+                List.of("tag"), "font", null
+        );
+        Diary diary = Diary.create(
+                "old", "old", null, LocalDateTime.now(),
+                member, emotion, tone, location, LocalDateTime.now(), LocalDateTime.now()
+        );
+        diary.setStyle(Style.create("old-font", diary, frame));
+
+        when(diaryRepository.findById(1L)).thenReturn(Optional.of(diary));
+        when(emotionRepository.findByName("HAPPY")).thenReturn(Optional.of(emotion));
+        when(toneRepository.findByName("calm")).thenReturn(Optional.of(tone));
+        when(locationRepository.findByAddressAndLatitudeAndLongitude("Seoul", 37.5, 127.0))
+                .thenReturn(Optional.of(location));
+        when(tagRepository.findByName("tag")).thenReturn(Optional.of(new Tag(1L, "tag", List.of())));
+
+        CustomException ex = assertThrows(CustomException.class,
+                () -> diaryService.updateDiary(1L, request, null));
+        assertEquals(DiaryExceptionResponseStatus.MISSING_FRAME, ex.getStatus());
+    }
+
+    @Test
+    void deleteDiary_s3Failure_throwsMappedException() {
+        Diary diary = Diary.create(
+                "content", "summary", null, LocalDateTime.now(),
+                member, emotion, tone, location, LocalDateTime.now(), LocalDateTime.now()
+        );
+        diary.setImage(Image.create("old-key", diary));
+
+        when(diaryRepository.findById(99L)).thenReturn(Optional.of(diary));
+        doThrow(new RuntimeException("s3 fail")).when(s3Service).deleteFileFromUrl("old-key");
+
+        CustomException ex = assertThrows(CustomException.class, () -> diaryService.deleteDiary(99L));
+        assertEquals(S3ExceptionResponseStatus.S3_DELETE_FAILED, ex.getStatus());
+        verify(diaryRepository, never()).delete(any());
+    }
+}

--- a/src/test/java/kuit/modi/service/MemberServiceTest.java
+++ b/src/test/java/kuit/modi/service/MemberServiceTest.java
@@ -1,0 +1,67 @@
+package kuit.modi.service;
+
+import kuit.modi.domain.CharacterType;
+import kuit.modi.domain.Member;
+import kuit.modi.dto.member.MemberRequest;
+import kuit.modi.exception.CustomException;
+import kuit.modi.exception.MemberExceptionResponseStatus;
+import kuit.modi.repository.CharacterTypeRepository;
+import kuit.modi.repository.DiaryRepository;
+import kuit.modi.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock private MemberRepository memberRepository;
+    @Mock private CharacterTypeRepository characterTypeRepository;
+    @Mock private DiaryRepository diaryRepository;
+    @InjectMocks private MemberService memberService;
+
+    @Test
+    void update_success() {
+        Member member = new Member("test@example.com", null);
+        member.setId(1L);
+        member.setNickname("old");
+        CharacterType characterType = new CharacterType(2L, "cat");
+        MemberRequest request = new MemberRequest("newNick", "cat");
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+        when(characterTypeRepository.findByName("cat")).thenReturn(Optional.of(characterType));
+        when(memberRepository.save(member)).thenReturn(member);
+
+        Member result = memberService.update(1L, request);
+
+        assertEquals("newNick", result.getNickname());
+        assertEquals(characterType, result.getCharacterType());
+    }
+
+    @Test
+    void deleteById_memberNotFound_throwsException() {
+        when(memberRepository.existsById(10L)).thenReturn(false);
+
+        CustomException ex = assertThrows(CustomException.class, () -> memberService.deleteById(10L));
+        assertEquals(MemberExceptionResponseStatus.MEMBER_NOT_FOUND, ex.getStatus());
+        verify(diaryRepository, never()).deleteAllByMemberId(anyLong());
+        verify(memberRepository, never()).deleteById(anyLong());
+    }
+
+    @Test
+    void deleteById_success_deletesDiariesThenMember() {
+        when(memberRepository.existsById(3L)).thenReturn(true);
+
+        memberService.deleteById(3L);
+
+        verify(diaryRepository).deleteAllByMemberId(3L);
+        verify(memberRepository).deleteById(3L);
+    }
+}

--- a/src/test/java/kuit/modi/service/ReminderServiceTest.java
+++ b/src/test/java/kuit/modi/service/ReminderServiceTest.java
@@ -1,0 +1,104 @@
+package kuit.modi.service;
+
+import kuit.modi.domain.*;
+import kuit.modi.dto.reminder.ReminderPagedResponse;
+import kuit.modi.dto.reminder.ReminderQueryParams;
+import kuit.modi.repository.DiaryRepository;
+import kuit.modi.repository.LocationRepository;
+import kuit.modi.repository.ReminderRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReminderServiceTest {
+
+    @Mock private LocationRepository locationRepository;
+    @Mock private DiaryRepository diaryRepository;
+    @Mock private ReminderRepository reminderRepository;
+    @InjectMocks private ReminderService reminderService;
+
+    @Test
+    void getRemindersByAddress_emptyLocations_returnsEmptyResponse() {
+        Member member = new Member("test@example.com", null);
+        member.setId(1L);
+
+        ReminderQueryParams params = new ReminderQueryParams("Seoul", null, null, 20, null);
+        when(locationRepository.findAllByAddress("Seoul")).thenReturn(List.of());
+
+        ReminderPagedResponse response = reminderService.getRemindersByAddress(member, params);
+
+        assertTrue(response.getItems().isEmpty());
+        assertNull(response.getNextCursor());
+    }
+
+    @Test
+    void getRemindersByAddress_withCursorAndOverflow_setsNextCursor() {
+        Member member = new Member("test@example.com", null);
+        member.setId(1L);
+
+        Location location = new Location(10L, "Seoul", 37.5, 127.0);
+        Emotion emotion = new Emotion(1L, "HAPPY");
+        Tone tone = new Tone(1L, "calm");
+        LocalDateTime now = LocalDateTime.of(2026, 5, 22, 10, 0);
+
+        Diary diary1 = Diary.create("c1", "s1", null, now, member, emotion, tone, location, now, now);
+        diary1.setId(101L);
+        Diary diary2 = Diary.create("c2", "s2", null, now.minusHours(1), member, emotion, tone, location, now.minusHours(1), now.minusHours(1));
+        diary2.setId(100L);
+        Diary diary3 = Diary.create("c3", "s3", null, now.minusHours(2), member, emotion, tone, location, now.minusHours(2), now.minusHours(2));
+        diary3.setId(99L);
+
+        String cursorRaw = "{\"id\":200,\"created_at\":\"2026-05-21T00:00:00\"}";
+        String cursor = Base64.getEncoder().encodeToString(cursorRaw.getBytes());
+        ReminderQueryParams params = new ReminderQueryParams("Seoul", Instant.now(), Instant.now(), 2, cursor);
+
+        when(locationRepository.findAllByAddress("Seoul")).thenReturn(List.of(location));
+        when(diaryRepository.findPagedDiariesByLocations(eq(1L), eq(List.of(10L)), any(), eq(200L), any(Pageable.class)))
+                .thenReturn(List.of(diary1, diary2, diary3));
+
+        ReminderPagedResponse response = reminderService.getRemindersByAddress(member, params);
+
+        assertEquals(2, response.getItems().size());
+        assertNotNull(response.getNextCursor());
+    }
+
+    @Test
+    void getRecentReminders_mapsToResponse() {
+        Member member = new Member("test@example.com", null);
+        member.setId(1L);
+        Location location = new Location(1L, "Busan", 35.1, 129.0);
+        Emotion emotion = new Emotion(1L, "CALM");
+        Reminder reminder = new Reminder(
+                11L,
+                LocalDateTime.ofInstant(Instant.ofEpochSecond(1_700_000_000L), ZoneOffset.UTC),
+                location,
+                LocalDateTime.of(2026, 5, 21, 9, 0),
+                emotion,
+                member
+        );
+
+        when(reminderRepository.findTop10ByMemberAndCreatedAtAfterOrderByCreatedAtDesc(eq(member), any(LocalDateTime.class)))
+                .thenReturn(List.of(reminder));
+
+        var responses = reminderService.getRecentReminders(member);
+
+        assertEquals(1, responses.size());
+        assertEquals(11L, responses.get(0).getId());
+        assertEquals("Busan", responses.get(0).getAddress());
+        assertEquals("CALM", responses.get(0).getEmotion());
+    }
+}


### PR DESCRIPTION
## 변경 목적
- 기존에 테스트 코드가 없던 상태에서 주요 서비스 로직에 대한 단위 테스트(JUnit/Mockito)를 추가
- CI에서 테스트를 강제하고, CD는 CI 성공 이후에만 동작하도록 워크플로우 개선
- 서버가 닫힌 상태여도 레포 상에서 CD 구성/동작 여부를 확인할 수 있도록 배포 워크플로우 보완
- Swagger UI를 추가해 API 명세를 즉시 확인 가능하도록 개선
- README를 프로젝트 소개/구조/실행 방법 중심으로 정리

## 주요 변경 사항

### 1) 테스트 코드 추가 (JUnit5 + Mockito)
- `DiaryServiceTest`
  - 일기 생성 성공 플로우
  - frame 누락 시 예외 처리
  - S3 삭제 실패 시 예외 매핑 검증
- `MemberServiceTest`
  - 회원 정보 수정 성공
  - 회원 미존재 삭제 요청 예외
  - 회원 삭제 시 연관 일기 삭제 호출 검증
- `ReminderServiceTest`
  - 위치 없음 케이스 빈 응답
  - 커서 기반 페이징 nextCursor 생성
  - 최근 알림 응답 매핑 검증
- 환경 의존성을 줄이기 위해 기존 `ModiApplicationTests`는 컨텍스트 로딩 대신 최소 검증 형태로 조정

### 2) CI/CD 워크플로우 개선
- `ci.yml` 신설
  - `main` 대상 `push`, `pull_request`에서 `./gradlew clean test` 수행
- `deploy.yml` 개선
  - CI 성공(`workflow_run`) 시에만 배포 수행
  - 수동 실행(`workflow_dispatch`) 지원
  - 배포 시크릿 미설정/서버 미사용 상태에서는 배포를 skip하고 메시지 출력 (레포에서 CD 구성 확인 가능)

### 3) Swagger UI/OpenAPI 추가
- `springdoc-openapi-starter-webmvc-ui` 의존성 추가
- `OpenApiConfig` 추가 (API 정보 + JWT Bearer 스키마)
- 문서 경로 설정
  - Swagger UI: `/swagger-ui.html`
  - OpenAPI JSON: `/api-docs`

### 4) README 정비
- 첫 줄 서비스 소개 및 Skills 명시
- 프로젝트 구조, 환경 변수, 실행/테스트 방법, Swagger, CI/CD 설명 추가
- 기존 ERD/API 링크/아키텍처 다이어그램 내용 유지

## 검증
- 로컬에서 `./gradlew test` 통과 확인