### PR TITLE
[FEAT] Cursor Pagination 구현 (createdAt+id 복합 커서, Base64 인코딩)

### DIFF
--- a/src/main/java/kuit/modi/controller/DiaryController.java
+++ b/src/main/java/kuit/modi/controller/DiaryController.java
@@ -125,11 +125,11 @@ public class DiaryController {
     }*/
 
     @GetMapping(params = {"year", "month"})
-    public ResponseEntity<DiaryPageResponse<DiaryMonthlyItemResponse>> getMonthlyDiaries(
+    public ResponseEntity<CursorPageResponse<DiaryMonthlyItemResponse>> getMonthlyDiaries(
             @AuthenticationPrincipal Member member,
             @RequestParam int year,
             @RequestParam int month,
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "20") int size
     ) {
         log.info("월별 기록 조회 API 호출: memberId={}, year={}, month={}", member.getId(), year, month);
@@ -137,22 +137,21 @@ public class DiaryController {
             throw new CustomException(DiaryExceptionResponseStatus.INVALID_YEAR_MONTH);
         }
 
-        DiaryPageResponse<DiaryMonthlyItemResponse> response =
-                diaryQueryService.getMonthlyDiariesPaged(year, month, member, page, size);
+        CursorPageResponse<DiaryMonthlyItemResponse> response =
+                diaryQueryService.getMonthlyDiariesCursor(year, month, member, cursor, size);
         return ResponseEntity.ok(response);
     }
 
-    // 즐겨찾기한 일기 목록 조회 (페이징 처리)
-    // - 사용자가 즐겨찾기한 일기를 페이징하여 반환
+    // 즐겨찾기한 일기 목록 조회 (커서 페이징)
     @GetMapping("/favorites")
-    public ResponseEntity<DiaryPageResponse<FavoriteDiaryItemResponse>> getFavoriteDiaries(
+    public ResponseEntity<CursorPageResponse<FavoriteDiaryItemResponse>> getFavoriteDiaries(
             @AuthenticationPrincipal Member member,
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "20") int size
     ) {
         log.info("즐겨찾기 일기 목록 조회 API 호출: memberId={}", member.getId());
-        DiaryPageResponse<FavoriteDiaryItemResponse> response =
-                diaryQueryService.getFavoriteDiariesPaged(member, page, size);
+        CursorPageResponse<FavoriteDiaryItemResponse> response =
+                diaryQueryService.getFavoriteDiariesCursor(member, cursor, size);
         return ResponseEntity.ok(response);
     }
 
@@ -180,25 +179,19 @@ public class DiaryController {
         return ResponseEntity.ok(diaryQueryService.getDiariesByTagName(tagName, member));
     }
 
-    // 태그 ID 기반 일기 검색 (페이징 처리)
-    // - tagId를 기반으로 해당 태그가 지정된 일기를 조회
-    // - 날짜별로 자동 그룹화하여 반환
-    // - date 내림차순 정렬
+    // 태그 ID 기반 일기 검색 (커서 페이징)
     @GetMapping("/by-tag")
-    public ResponseEntity<DiaryPageResponse<DiaryTagSearchItemResponse>> getDiariesByTagId(
+    public ResponseEntity<CursorPageResponse<DiaryTagSearchItemResponse>> getDiariesByTagId(
             @AuthenticationPrincipal Member member,
             @RequestParam Long tagId,
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "20") int size
     ) {
         log.info("태그 Id 기반 검색 API 호출: memberId={}, tagId={}", member.getId(), tagId);
-        // size 최대값 제한
-        if (size > 100) {
-            size = 100;
-        }
+        if (size > 100) size = 100;
 
-        DiaryPageResponse<DiaryTagSearchItemResponse> response =
-                diaryQueryService.getDiariesByTagIdPaged(member, tagId, page, size);
+        CursorPageResponse<DiaryTagSearchItemResponse> response =
+                diaryQueryService.getDiariesByTagIdCursor(member, tagId, cursor, size);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/kuit/modi/dto/diary/response/CursorPageResponse.java
+++ b/src/main/java/kuit/modi/dto/diary/response/CursorPageResponse.java
@@ -1,0 +1,14 @@
+package kuit.modi.dto.diary.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CursorPageResponse<T> {
+    private List<T> content;
+    private String nextCursor;
+    private boolean hasNext;
+}

--- a/src/main/java/kuit/modi/repository/DiaryQueryRepository.java
+++ b/src/main/java/kuit/modi/repository/DiaryQueryRepository.java
@@ -2,6 +2,7 @@ package kuit.modi.repository;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.TypedQuery;
 import kuit.modi.domain.Diary;
 import kuit.modi.domain.Member;
 import org.springframework.data.domain.Page;
@@ -390,6 +391,81 @@ public class DiaryQueryRepository {
                 .setParameter("memberId", memberId)
                 .setParameter("tagId", tagId)
                 .getSingleResult();
+    }
+
+    // 월별 조회 - createdAt+id 복합 커서 기반
+    public List<Diary> findByYearMonthCursor(Long memberId, int year, int month,
+            LocalDateTime lastCreatedAt, Long lastId, int size) {
+        String jpql = "SELECT d FROM Diary d " +
+                "LEFT JOIN FETCH d.image " +
+                "LEFT JOIN FETCH d.emotion " +
+                "WHERE d.member.id = :memberId " +
+                "AND FUNCTION('YEAR', d.date) = :year " +
+                "AND FUNCTION('MONTH', d.date) = :month ";
+        if (lastCreatedAt != null) {
+            jpql += "AND (d.createdAt < :lastCreatedAt " +
+                    "OR (d.createdAt = :lastCreatedAt AND d.id < :lastId)) ";
+        }
+        jpql += "ORDER BY d.createdAt DESC, d.id DESC";
+
+        TypedQuery<Diary> query = em.createQuery(jpql, Diary.class)
+                .setParameter("memberId", memberId)
+                .setParameter("year", year)
+                .setParameter("month", month)
+                .setMaxResults(size + 1);
+        if (lastCreatedAt != null) {
+            query.setParameter("lastCreatedAt", lastCreatedAt);
+            query.setParameter("lastId", lastId);
+        }
+        return query.getResultList();
+    }
+
+    // 즐겨찾기 조회 - createdAt+id 복합 커서 기반
+    public List<Diary> findFavoritesCursor(Long memberId, LocalDateTime lastCreatedAt, Long lastId, int size) {
+        String jpql = "SELECT d FROM Diary d " +
+                "LEFT JOIN FETCH d.image " +
+                "WHERE d.member.id = :memberId " +
+                "AND d.favorite = true ";
+        if (lastCreatedAt != null) {
+            jpql += "AND (d.createdAt < :lastCreatedAt " +
+                    "OR (d.createdAt = :lastCreatedAt AND d.id < :lastId)) ";
+        }
+        jpql += "ORDER BY d.createdAt DESC, d.id DESC";
+
+        TypedQuery<Diary> query = em.createQuery(jpql, Diary.class)
+                .setParameter("memberId", memberId)
+                .setMaxResults(size + 1);
+        if (lastCreatedAt != null) {
+            query.setParameter("lastCreatedAt", lastCreatedAt);
+            query.setParameter("lastId", lastId);
+        }
+        return query.getResultList();
+    }
+
+    // 태그 ID 기반 조회 - createdAt+id 복합 커서 기반
+    public List<Diary> findByTagIdCursor(Long memberId, Long tagId,
+            LocalDateTime lastCreatedAt, Long lastId, int size) {
+        String jpql = "SELECT DISTINCT d FROM Diary d " +
+                "LEFT JOIN FETCH d.image " +
+                "WHERE d.member.id = :memberId " +
+                "AND EXISTS (" +
+                "  SELECT 1 FROM DiaryTag dt " +
+                "  WHERE dt.diary = d AND dt.tag.id = :tagId) ";
+        if (lastCreatedAt != null) {
+            jpql += "AND (d.createdAt < :lastCreatedAt " +
+                    "OR (d.createdAt = :lastCreatedAt AND d.id < :lastId)) ";
+        }
+        jpql += "ORDER BY d.createdAt DESC, d.id DESC";
+
+        TypedQuery<Diary> query = em.createQuery(jpql, Diary.class)
+                .setParameter("memberId", memberId)
+                .setParameter("tagId", tagId)
+                .setMaxResults(size + 1);
+        if (lastCreatedAt != null) {
+            query.setParameter("lastCreatedAt", lastCreatedAt);
+            query.setParameter("lastId", lastId);
+        }
+        return query.getResultList();
     }
 
 }

--- a/src/main/java/kuit/modi/service/DiaryQueryService.java
+++ b/src/main/java/kuit/modi/service/DiaryQueryService.java
@@ -12,6 +12,7 @@ import kuit.modi.exception.DiaryExceptionResponseStatus;
 import kuit.modi.repository.DiaryQueryRepository;
 import kuit.modi.repository.DiaryTagRepository;
 import kuit.modi.repository.TagRepository;
+import kuit.modi.util.CursorUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -465,6 +466,132 @@ public class DiaryQueryService {
         boolean hasNext = (page + 1) < totalPages;
 
         return new DiaryPageResponse<>(content, page, size, totalElements, totalPages, hasNext);
+    }
+
+    // 월별 조회 - createdAt+id 복합 커서 기반
+    @Transactional(readOnly = true)
+    public CursorPageResponse<DiaryMonthlyItemResponse> getMonthlyDiariesCursor(
+            int year, int month, Member member, String cursor, int size) {
+
+        if (month < 1 || month > 12) {
+            throw new CustomException(DiaryExceptionResponseStatus.INVALID_YEAR_MONTH);
+        }
+
+        CursorUtils.Decoded decoded = (cursor != null && !cursor.isBlank())
+                ? CursorUtils.decode(cursor) : null;
+
+        List<Diary> diaries = diaryQueryRepository.findByYearMonthCursor(
+                member.getId(), year, month,
+                decoded != null ? decoded.createdAt() : null,
+                decoded != null ? decoded.id() : null,
+                size);
+
+        boolean hasNext = diaries.size() > size;
+        if (hasNext) diaries = new ArrayList<>(diaries.subList(0, size));
+
+        List<DiaryMonthlyItemResponse> content = diaries.stream()
+                .map(diary -> new DiaryMonthlyItemResponse(
+                        diary.getId(),
+                        diary.getDate().toLocalDate(),
+                        diary.getImage() != null ? s3Service.getFileUrl(diary.getImage().getUrl()) : null,
+                        diary.getEmotion().getName(),
+                        diary.getCreatedAt()
+                ))
+                .toList();
+
+        String nextCursor = hasNext
+                ? CursorUtils.encode(
+                        diaries.get(diaries.size() - 1).getCreatedAt(),
+                        diaries.get(diaries.size() - 1).getId())
+                : null;
+
+        return new CursorPageResponse<>(content, nextCursor, hasNext);
+    }
+
+    // 즐겨찾기 조회 - createdAt+id 복합 커서 기반
+    @Transactional(readOnly = true)
+    public CursorPageResponse<FavoriteDiaryItemResponse> getFavoriteDiariesCursor(
+            Member member, String cursor, int size) {
+
+        CursorUtils.Decoded decoded = (cursor != null && !cursor.isBlank())
+                ? CursorUtils.decode(cursor) : null;
+
+        List<Diary> diaries = diaryQueryRepository.findFavoritesCursor(
+                member.getId(),
+                decoded != null ? decoded.createdAt() : null,
+                decoded != null ? decoded.id() : null,
+                size);
+
+        boolean hasNext = diaries.size() > size;
+        if (hasNext) diaries = new ArrayList<>(diaries.subList(0, size));
+
+        List<FavoriteDiaryItemResponse> content = diaries.stream()
+                .map(diary -> new FavoriteDiaryItemResponse(
+                        diary.getId(),
+                        diary.getDate().toLocalDate(),
+                        diary.getImage() != null ? s3Service.getFileUrl(diary.getImage().getUrl()) : null,
+                        diary.getCreatedAt()
+                ))
+                .toList();
+
+        String nextCursor = hasNext
+                ? CursorUtils.encode(
+                        diaries.get(diaries.size() - 1).getCreatedAt(),
+                        diaries.get(diaries.size() - 1).getId())
+                : null;
+
+        return new CursorPageResponse<>(content, nextCursor, hasNext);
+    }
+
+    // 태그 ID 기반 조회 - createdAt+id 복합 커서 기반
+    @Transactional(readOnly = true)
+    public CursorPageResponse<DiaryTagSearchItemResponse> getDiariesByTagIdCursor(
+            Member member, Long tagId, String cursor, int size) {
+
+        if (tagId == null || tagId <= 0) {
+            throw new CustomException(DiaryExceptionResponseStatus.INVALID_TAG_ID);
+        }
+
+        CursorUtils.Decoded decoded = (cursor != null && !cursor.isBlank())
+                ? CursorUtils.decode(cursor) : null;
+
+        List<Diary> diaries = diaryQueryRepository.findByTagIdCursor(
+                member.getId(), tagId,
+                decoded != null ? decoded.createdAt() : null,
+                decoded != null ? decoded.id() : null,
+                size);
+
+        boolean hasNext = diaries.size() > size;
+        if (hasNext) diaries = new ArrayList<>(diaries.subList(0, size));
+
+        // 날짜별 그룹화 (최신순)
+        Map<LocalDate, Map<Long, List<String>>> byDate = new TreeMap<>(Collections.reverseOrder());
+        for (Diary diary : diaries) {
+            LocalDate date = diary.getDate().toLocalDate();
+            String imageUrl = diary.getImage() != null
+                    ? s3Service.getFileUrl(diary.getImage().getUrl()) : null;
+            byDate.computeIfAbsent(date, d -> new LinkedHashMap<>())
+                    .computeIfAbsent(diary.getId(), id -> new ArrayList<>())
+                    .add(imageUrl);
+        }
+
+        List<DiaryTagSearchItemResponse> content = byDate.entrySet().stream()
+                .map(entry -> new DiaryTagSearchItemResponse(
+                        entry.getKey(),
+                        entry.getValue().entrySet().stream()
+                                .map(e -> new DiaryImageGroupResponse(
+                                        e.getKey(),
+                                        e.getValue().stream().filter(Objects::nonNull).collect(Collectors.toList())))
+                                .toList()))
+                .toList();
+
+        String nextCursor = hasNext
+                ? CursorUtils.encode(
+                        diaries.get(diaries.size() - 1).getCreatedAt(),
+                        diaries.get(diaries.size() - 1).getId())
+                : null;
+
+        return new CursorPageResponse<>(content, nextCursor, hasNext);
     }
 
 }

--- a/src/main/java/kuit/modi/util/CursorUtils.java
+++ b/src/main/java/kuit/modi/util/CursorUtils.java
@@ -1,0 +1,25 @@
+package kuit.modi.util;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+public class CursorUtils {
+
+    private static final DateTimeFormatter FMT = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    public record Decoded(LocalDateTime createdAt, Long id) {}
+
+    public static String encode(LocalDateTime createdAt, Long id) {
+        String raw = createdAt.format(FMT) + "|" + id;
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static Decoded decode(String cursor) {
+        String raw = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+        String[] parts = raw.split("\\|", 2);
+        return new Decoded(LocalDateTime.parse(parts[0], FMT), Long.parseLong(parts[1]));
+    }
+}


### PR DESCRIPTION
## Summary

- `createdAt + id` 복합 커서를 Base64URL 인코딩하여 전달하는 Cursor Pagination 구현
- 동일한 `createdAt`이 존재해도 `id`를 보조 정렬 기준으로 사용해 페이지 간 중복·누락 없이 안정적으로 조회
- 월별 조회 / 즐겨찾기 / 태그 기반 조회 3개 엔드포인트를 offset → cursor 방식으로 전환

## Changes

- **`CursorUtils`**: `encode(createdAt, id)` → Base64URL 문자열, `decode(cursor)` → `createdAt`, `id` 추출
- **`CursorPageResponse<T>`**: `content`, `nextCursor`, `hasNext` 포함 응답 DTO
- **`DiaryQueryRepository`**: `findByYearMonthCursor`, `findFavoritesCursor`, `findByTagIdCursor` 추가
  - `WHERE (createdAt < :last OR (createdAt = :last AND id < :lastId))` 조건으로 커서 구현
  - `size + 1` 조회로 `hasNext` 판별
- **`DiaryController`**: `page` 파라미터 → `cursor` 파라미터로 전환

## Test plan

- [ ] `GET /api/diaries?year=2025&month=11&size=5` → 첫 페이지 `nextCursor` 반환 확인
- [ ] 응답의 `nextCursor` 값을 `cursor` 파라미터로 재요청 → 다음 페이지 정상 반환 확인
- [ ] 마지막 페이지에서 `hasNext: false`, `nextCursor: null` 확인
- [ ] 동일 `createdAt` 데이터 존재 시 중복/누락 없이 조회되는지 확인
- [ ] `/api/diaries/favorites`, `/api/diaries/by-tag` 동일 시나리오 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)